### PR TITLE
Added actions in KB

### DIFF
--- a/knowledge-base/aliyun/ack-set-context/action-security.yml
+++ b/knowledge-base/aliyun/ack-set-context/action-security.yml
@@ -1,0 +1,5 @@
+name: Setting context for Kubernetes cluster of Alibaba Cloud Kubernetes Service (ACK)
+outbound-endpoints:
+  - fqdn: cs.aliyuncs.com
+    port: 443
+    reason: to query cluster user's configurations

--- a/knowledge-base/microsoft/psscriptanalyzer-action/action-security.yml
+++ b/knowledge-base/microsoft/psscriptanalyzer-action/action-security.yml
@@ -1,0 +1,14 @@
+name: Run PSScriptAnalyzer
+outbound-endpoints:
+  # NOTE: https://docs.microsoft.com/en-us/powershell/scripting/gallery/getting-started?view=powershell-7.2#network-access-to-the-powershell-gallery
+  - fqdn: www.powershellgallery.com
+    port: 443
+    reason: to fetch powershell modules
+  
+  - fqdn:  psg-prod-eastus.azureedge.net.
+    port: 443
+    reason: to download powershell modules
+
+  - fqdn: az818661.vo.msecnd.net
+    port: 443
+    reason: to download powershell modules 

--- a/knowledge-base/microsoft/psscriptanalyzer-action/action-security.yml
+++ b/knowledge-base/microsoft/psscriptanalyzer-action/action-security.yml
@@ -12,3 +12,4 @@ outbound-endpoints:
   - fqdn: az818661.vo.msecnd.net
     port: 443
     reason: to download powershell modules 
+harden-runner-link: https://app.stepsecurity.io/github/h0x0er/kb_setup/actions/runs/1706707156

--- a/knowledge-base/redhat-actions/openshift-tools-installer/action-security.yml
+++ b/knowledge-base/redhat-actions/openshift-tools-installer/action-security.yml
@@ -7,7 +7,7 @@ github-token:
                # so maybe only `read` permission is required.
                # GITHUB_TOKEN is used only to avoid rate-limit
 
-outbound-endpoints: 
+outbound-endpoints:
   - fqdn: mirror.openshift.com
     port: 443
     reason: to download openshift-tools-installer from mirror
@@ -17,5 +17,5 @@ outbound-endpoints:
     reason: to download openshift-tools-installer from github
 
   - fqdn: api.github.com
-    port: 443 
+    port: 443
     reason: to query info about sepcific release-tag

--- a/knowledge-base/redhat-actions/openshift-tools-installer/action-security.yml
+++ b/knowledge-base/redhat-actions/openshift-tools-installer/action-security.yml
@@ -18,4 +18,4 @@ outbound-endpoints:
 
   - fqdn: api.github.com
     port: 443
-    reason: to query info about sepcific release-tag
+    reason: to query info about specific release-tag

--- a/knowledge-base/redhat-actions/openshift-tools-installer/action-security.yml
+++ b/knowledge-base/redhat-actions/openshift-tools-installer/action-security.yml
@@ -1,0 +1,21 @@
+name: OpenShift Tools Installer
+github-token:
+  action-input:
+    input: github-pat
+    is-default: true
+  permissions: # NOTE: github_api call is only made to releases_endpoint to query tag info.(public-endpoint)
+               # so maybe only `read` permission is required.
+               # GITHUB_TOKEN is used only to avoid rate-limit
+
+outbound-endpoints: 
+  - fqdn: mirror.openshift.com
+    port: 443
+    reason: to download openshift-tools-installer from mirror
+
+  - fqdn: github.com
+    port: 443
+    reason: to download openshift-tools-installer from github
+
+  - fqdn: api.github.com
+    port: 443 
+    reason: to query info about sepcific release-tag


### PR DESCRIPTION
As per [here](https://github.com/redhat-actions/openshift-tools-installer/blob/01ccdb970d15e84aa65b8714a8b1a137aa55496f/src/github-client-finder/repository-finder.ts#L39), `GITHUB_TOKEN` is used only to avoid rate-limiting. 