### PR TITLE
Create action-security.yml

### DIFF
--- a/knowledge-base/azure/k8s-deploy/action-security.yml
+++ b/knowledge-base/azure/k8s-deploy/action-security.yml
@@ -1,0 +1,14 @@
+name: 'Deploy to Kubernetes cluster'
+github-token:
+  action-input:
+    input: token
+    is-default: true
+  permissions:
+    contents: read
+    contents-reason: to query workflow path
+    issues: write
+    issues-reason: to set issues as idle
+    pull-requests: write
+    pull-requests-reason: to set PRs as idle
+    
+harden-runner-link: https://app.stepsecurity.io/github/arjundashrath/StepSecurity_Tests/actions/runs/1729871674 

--- a/knowledge-base/azure/k8s-deploy/action-security.yml
+++ b/knowledge-base/azure/k8s-deploy/action-security.yml
@@ -4,11 +4,7 @@ github-token:
     input: token
     is-default: true
   permissions:
-    contents: read
-    contents-reason: to query workflow path
-    issues: write
-    issues-reason: to set issues as idle
-    pull-requests: write
-    pull-requests-reason: to set PRs as idle
+    actions: read
+    actions-reason: to query workflow path #Reference: https://github.com/Azure/k8s-deploy/blob/ac49626466364585521685ccaad17e499a8263a8/src/githubClient.ts#L11
     
 harden-runner-link: https://app.stepsecurity.io/github/arjundashrath/StepSecurity_Tests/actions/runs/1729871674 


### PR DESCRIPTION
@varunsh-coder I had some trouble deploying the action on my test repository as it was being deemed invalid in the builds, hence the harden runner link does not really show anything for the outbound endpoints, any suggestions? I have updated the github token permissions 