### PR TITLE
Add error for re-usable workflows

### DIFF
--- a/testfiles/reusableWorkflow/workflow.yml
+++ b/testfiles/reusableWorkflow/workflow.yml
@@ -1,0 +1,23 @@
+name: platform_close
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/platform_close_workflow.yaml
+      - flutter_nps/packages/platform_close/**
+
+
+jobs:
+  build:
+    steps:
+    - name: build
+      uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+      with:
+        working_directory: "flutter_nps/packages/platform_close"
+        coverage_excludes: "*.g.dart lib/gen/*.gen.dart"
+        flutter_channel: stable
+        flutter_version: 2.10.0


### PR DESCRIPTION
closes #747 
@varunsh-coder , I found the issue with the workflow:

The workflow

```
name: platform_close

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true

on:
  pull_request:
    paths:
      - .github/workflows/platform_close_workflow.yaml
      - flutter_nps/packages/platform_close/**


jobs:
  build:
    name: build
    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
    with:
      working_directory: "flutter_nps/packages/platform_close"
      coverage_excludes: "*.g.dart lib/gen/*.gen.dart"
      flutter_channel: stable
      flutter_version: 2.10.0
```

does not contain `steps:` after job name and also does not contain the symbol `-` before `name:`. Missing either of these makes the program parse the workflow incorrectly such that there are no steps registered. This workflow follows the correct yaml syntax, but just misses out on the two above-mentioned things, hence we do not get a parsing error. In the future we can add code to take care of such cases.