### PR TITLE
Add SVGO-Action to the knowledge base

### DIFF
--- a/knowledge-base/actions/ericcornelissen/svgo-action/action-security.yml
+++ b/knowledge-base/actions/ericcornelissen/svgo-action/action-security.yml
@@ -1,0 +1,14 @@
+name: SVGO action
+github-token:
+  action-input:
+    input: repo-token
+    is-default: false
+  permissions:
+    contents: read
+    contents-reason: to determine what SVGs to optimize
+    pull-requests: read
+    pull-requests-reason: to determine what SVGs to optimize
+outbound-endpoints:
+  - fqdn: api.github.com
+    port: 443
+    reason: to call GitHub Issues or Pull


### PR DESCRIPTION
This adds a YAML file to describe token permissions and outbound endpoints needed for the Action: [ericcornelissen/svgo-action]

I would've wanted to add `contents-if` and `pull-requests-if` as the token is only needed if [ericcornelissen/svgo-action] is used `on: push` or `on: pull-request` (resp.). But I was unsure how the encode that in the `<scope>-if` syntax.

References:

- [Permissions docs](https://github.com/ericcornelissen/svgo-action/tree/db316a65ff06f7cf6a917636ae3f8196c4703196#token-permissions)
- [Token input docs](https://github.com/ericcornelissen/svgo-action/blob/db316a65ff06f7cf6a917636ae3f8196c4703196/docs/inputs.md#repository-token)

[ericcornelissen/svgo-action]: https://github.com/ericcornelissen/svgo-action