### PR TITLE
[FIX] Harden-runner gets added for reusable jobs

### DIFF
--- a/actionmetadata.go
+++ b/actionmetadata.go
@@ -178,3 +178,7 @@ func GetActionKnowledgeBase(action string) (*ActionMetadata, error) {
 
 	return &actionMetadata, nil
 }
+
+func IsCallingReusableWorkflow(job Job) bool {
+	return len(job.Uses) > 0
+}

--- a/addaction.go
+++ b/addaction.go
@@ -17,6 +17,10 @@ func AddAction(inputYaml, action string) (string, bool, error) {
 	out := inputYaml
 
 	for jobName, job := range workflow.Jobs {
+		// Skip adding action for reusable jobs
+		if len(job.Uses) > 0 {
+			continue
+		}
 		alreadyPresent := false
 		for _, step := range job.Steps {
 			if len(step.Uses) > 0 && strings.HasPrefix(step.Uses, HardenRunnerActionPath) {

--- a/addaction.go
+++ b/addaction.go
@@ -18,7 +18,7 @@ func AddAction(inputYaml, action string) (string, bool, error) {
 
 	for jobName, job := range workflow.Jobs {
 		// Skip adding action for reusable jobs
-		if len(job.Uses) > 0 {
+		if IsCallingReusableWorkflow(job) {
 			continue
 		}
 		alreadyPresent := false

--- a/addaction_test.go
+++ b/addaction_test.go
@@ -24,6 +24,7 @@ func TestAddAction(t *testing.T) {
 		{name: "two jobs", args: args{inputYaml: "2jobs.yml", action: "step-security/harden-runner@v1"}, want: "2jobs.yml", wantErr: false, wantUpdated: true},
 		{name: "already present", args: args{inputYaml: "alreadypresent.yml", action: "step-security/harden-runner@v1"}, want: "alreadypresent.yml", wantErr: false, wantUpdated: true},
 		{name: "already present 2", args: args{inputYaml: "alreadypresent_2.yml", action: "step-security/harden-runner@v1"}, want: "alreadypresent_2.yml", wantErr: false, wantUpdated: false},
+		{name: "reusable job", args: args{inputYaml: "reusablejob.yml", action: "step-security/harden-runner@v1"}, want: "reusablejob.yml", wantErr: false, wantUpdated: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/permissions.go
+++ b/permissions.go
@@ -173,7 +173,7 @@ func AddJobLevelPermissions(inputYaml string) (*SecureWorkflowReponse, error) {
 			continue
 		}
 
-		if len(job.Uses) > 0 {
+		if IsCallingReusableWorkflow(job) {
 			fixWorkflowPermsReponse.HasErrors = true
 			errors[jobName] = append(errors[jobName], fmt.Sprintf(errorReusableWorkflow, job.Uses))
 			continue

--- a/testfiles/addaction/input/reusablejob.yml
+++ b/testfiles/addaction/input/reusablejob.yml
@@ -11,3 +11,9 @@ jobs:
     uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@main
     with:
       duration: 5m
+  
+  list-directory:
+    runs-on: ubuntu-latest
+    steps:
+     - uses: step-security/harden-runner@7206db2ec98c5538323a6d70e51f965d55c11c87
+     - run: ls -R

--- a/testfiles/addaction/input/reusablejob.yml
+++ b/testfiles/addaction/input/reusablejob.yml
@@ -1,0 +1,13 @@
+name: "Fuzz"
+
+on:
+  push:
+  
+
+jobs:  
+  fuzz:
+    name: Fuzz
+    needs: [e2e]
+    uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@main
+    with:
+      duration: 5m

--- a/testfiles/addaction/output/reusablejob.yml
+++ b/testfiles/addaction/output/reusablejob.yml
@@ -11,3 +11,9 @@ jobs:
     uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@main
     with:
       duration: 5m
+  
+  list-directory:
+    runs-on: ubuntu-latest
+    steps:
+     - uses: step-security/harden-runner@7206db2ec98c5538323a6d70e51f965d55c11c87
+     - run: ls -R

--- a/testfiles/addaction/output/reusablejob.yml
+++ b/testfiles/addaction/output/reusablejob.yml
@@ -1,0 +1,13 @@
+name: "Fuzz"
+
+on:
+  push:
+  
+
+jobs:  
+  fuzz:
+    name: Fuzz
+    needs: [e2e]
+    uses: ericcornelissen/shescape/.github/workflows/reusable-fuzz.yml@main
+    with:
+      duration: 5m


### PR DESCRIPTION
- The reason for harden-runner being added in this issue is because the job above it is a type of reusable job ([here](https://github.com/ericcornelissen/shescape/blob/16604e1b3eaa4acb83d37e75b198070c104a63ca/.github/workflows/test.yml#L191)).
- I have added the condition for skipping these jobs, and also added the test case for the same.

closes #1150 