### PR TITLE
Add Git Tag Annotation action to the knowledge base

### DIFF
--- a/knowledge-base/actions/ericcornelissen/git-tag-annotation-action/action-security.yml
+++ b/knowledge-base/actions/ericcornelissen/git-tag-annotation-action/action-security.yml
@@ -1,0 +1,2 @@
+name: Git Tag Annotation
+# GITHUB_TOKEN not used


### PR DESCRIPTION
This adds a YAML file to describe token permissions needed for the Action: [ericcornelissen/git-tag-annotation-action]

The action does not need token permissions nor does it make any connections to outbound endpoints.

[ericcornelissen/git-tag-annotation-action]: https://github.com/ericcornelissen/git-tag-annotation-action