### PR TITLE
[KB] Add GitHub token permissions for atsign-company/certinfo-action Action

### DIFF
--- a/knowledge-base/actions/atsign-company/certinfo-action/action-security.yml
+++ b/knowledge-base/actions/atsign-company/certinfo-action/action-security.yml
@@ -1,0 +1,2 @@
+name: 'Install Certinfo' # atsign-company/certinfo-action
+# GITHUB_TOKEN not used


### PR DESCRIPTION
#1462 seems to be failing tests, perhaps due to a stray CR in `action-security.yml`:

![image](https://user-images.githubusercontent.com/478926/202687723-4dea810f-3426-49fe-98bc-443e8b330b6c.png)

This relates to #1461 