### PR TITLE
[ISSUE] Update Names of `WorkflowParameters` struct properties to UpperCase

### DIFF
--- a/remediation/workflow/addworkflow.go
+++ b/remediation/workflow/addworkflow.go
@@ -12,8 +12,8 @@ import (
 const CodeQLWorkflowFileName = "codeql.yml"
 
 type WorkflowParameters struct {
-	languagesToAdd []string
-	defaultBranch  string
+	LanguagesToAdd []string
+	DefaultBranch  string
 }
 
 func getTemplate(file string) (string, error) {
@@ -38,9 +38,9 @@ func AddWorkflow(name string, workflowParameters WorkflowParameters) (string, er
 			return "", err
 		}
 
-		sort.Strings(workflowParameters.languagesToAdd)
-		codeqlWorkflow = strings.ReplaceAll(codeqlWorkflow, "$default-branch", fmt.Sprintf(`"%s"`, workflowParameters.defaultBranch))
-		codeqlWorkflow = strings.ReplaceAll(codeqlWorkflow, "$detected-codeql-languages", strings.Join(workflowParameters.languagesToAdd, ", "))
+		sort.Strings(workflowParameters.LanguagesToAdd)
+		codeqlWorkflow = strings.ReplaceAll(codeqlWorkflow, "$default-branch", fmt.Sprintf(`"%s"`, workflowParameters.DefaultBranch))
+		codeqlWorkflow = strings.ReplaceAll(codeqlWorkflow, "$detected-codeql-languages", strings.Join(workflowParameters.LanguagesToAdd, ", "))
 		codeqlWorkflow = strings.ReplaceAll(codeqlWorkflow, "$cron-weekly", fmt.Sprintf(`"%s"`, "0 0 * * 1")) // Note: Runs every monday at 12:00 AM
 
 		return codeqlWorkflow, nil

--- a/remediation/workflow/addworkflow_test.go
+++ b/remediation/workflow/addworkflow_test.go
@@ -16,8 +16,8 @@ func Test_AddWorkflow(t *testing.T) {
 		{
 			workflowName: "codeql",
 			workflowParameters: WorkflowParameters{
-				languagesToAdd: []string{"cpp", "go", "java"},
-				defaultBranch:  "main",
+				LanguagesToAdd: []string{"cpp", "go", "java"},
+				DefaultBranch:  "main",
 			},
 			expectedError:      false,
 			expectedOutputFile: "../../testfiles/expected-codeql.yml",
@@ -25,8 +25,8 @@ func Test_AddWorkflow(t *testing.T) {
 		{
 			workflowName: "xyz",
 			workflowParameters: WorkflowParameters{
-				languagesToAdd: []string{"cpp"},
-				defaultBranch:  "main",
+				LanguagesToAdd: []string{"cpp"},
+				DefaultBranch:  "main",
 			},
 			expectedError:      true,
 			expectedOutputFile: "",


### PR DESCRIPTION
Updated the names of the `WorkflowParameters` struct properties to UpperCase, so they can be used while initilizing the struct into different package.
@varunsh-coder please review the changes.