### PR TITLE
Add k1LoW/octocov-action

### DIFF
--- a/knowledge-base/actions/k1LoW/octocov-action/action-security.yml
+++ b/knowledge-base/actions/k1LoW/octocov-action/action-security.yml
@@ -1,0 +1,12 @@
+name: 'GitHub Action for octocov'
+github-token:
+  action-input:
+    input: repo_token
+    is-default: true
+  permissions:
+    # To comment on PRs
+    pull-requests: write
+    # To retrieve test step time in GitHub Action
+    contents: read
+    # To retrieve previous report for default branch, which is saved as GitHub Action Artifacts
+    actions: read


### PR DESCRIPTION
This PR adds action security for https://github.com/k1LoW/octocov-action

I am not an author of the action, but just an user.

I've observed those permissions on actual GitHub Action runs, since it is not obvious to understand how GH API is used in the action.
