### PR TITLE
Add harden-runner test cases for coverage and custom actions

### DIFF
--- a/remediation/workflow/hardenrunner/addaction_test.go
+++ b/remediation/workflow/hardenrunner/addaction_test.go
@@ -55,6 +55,68 @@ func TestAddAction(t *testing.T) {
 	}
 }
 
+func TestCustomActionConfig(t *testing.T) {
+	const inputDirectory = "../../../testfiles/addaction/input"
+	const outputDirectory = "../../../testfiles/addaction/output"
+
+	customConfig := "- name: Security Scanner\n  uses: org/security-scanner@v3\n  with:\n    mode: strict\n    scan-level: deep"
+
+	customConfigWithEndpoints := "- name: Harden the runner\n  uses: acme-corp/harden-runner@v2\n  with:\n    egress-policy: block\n    allowed-endpoints: >\n      github.com:443\n      registry.npmjs.org:443"
+
+	tests := []struct {
+		name        string
+		inputFile   string
+		config      HardenRunnerConfig
+		wantUpdated bool
+		outputFile  string
+	}{
+		{
+			name:        "add custom action to single job",
+			inputFile:   "customAction.yml",
+			config:      HardenRunnerConfig{Config: customConfig},
+			wantUpdated: true,
+			outputFile:  "customAction.yml",
+		},
+		{
+			name:        "add custom action with endpoints to two jobs",
+			inputFile:   "customActionTwoJobs.yml",
+			config:      HardenRunnerConfig{Config: customConfigWithEndpoints},
+			wantUpdated: true,
+			outputFile:  "customActionTwoJobs.yml",
+		},
+		{
+			name:        "subtractive replaces harden-runner with custom action",
+			inputFile:   "updateConfig.yml",
+			config:      HardenRunnerConfig{Config: customConfigWithEndpoints, Subtractive: true},
+			wantUpdated: true,
+			outputFile:  "customActionSubtractive.yml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, err := ioutil.ReadFile(path.Join(inputDirectory, tt.inputFile))
+			if err != nil {
+				t.Fatalf("error reading input file: %v", err)
+			}
+			got, gotUpdated, err := AddAction(string(input), tt.config, false, false, false)
+			if err != nil {
+				t.Errorf("AddAction() error = %v", err)
+			}
+			if gotUpdated != tt.wantUpdated {
+				t.Errorf("AddAction() updated = %v, wantUpdated %v", gotUpdated, tt.wantUpdated)
+			}
+			expected, err := ioutil.ReadFile(path.Join(outputDirectory, tt.outputFile))
+			if err != nil {
+				t.Fatalf("error reading output file: %v", err)
+			}
+			if got != string(expected) {
+				t.Errorf("AddAction() output mismatch\nGot:\n%s\nWant:\n%s", got, string(expected))
+			}
+		})
+	}
+}
+
 func TestUpdateHardenRunnerConfig(t *testing.T) {
 	const inputDirectory = "../../../testfiles/addaction/input"
 	const outputDirectory = "../../../testfiles/addaction/output"

--- a/remediation/workflow/hardenrunner/addaction_test.go
+++ b/remediation/workflow/hardenrunner/addaction_test.go
@@ -112,6 +112,13 @@ func TestUpdateHardenRunnerConfig(t *testing.T) {
 			wantUpdated: true,
 			outputFile:  "updateConfigWithConfigComments.yml",
 		},
+		{
+			name:        "subtractive replaces harden-runner as last step",
+			inputFile:   "updateConfigLastStep.yml",
+			config:      HardenRunnerConfig{Config: blockConfig, Subtractive: true},
+			wantUpdated: true,
+			outputFile:  "updateConfigLastStep.yml",
+		},
 	}
 
 	for _, tt := range tests {
@@ -198,6 +205,7 @@ func TestRunnerLabelFiltering(t *testing.T) {
 				RunnerLabels:     []string{"ubuntu-latest"},
 			},
 			wantUpdated: true,
+			outputFile:  "labelNoMatch-skipDisabled.yml",
 		},
 		{
 			name:      "empty labels list does not filter",
@@ -269,6 +277,16 @@ func TestRunnerLabelFiltering(t *testing.T) {
 			wantUpdated: false,
 			unchanged:   true,
 		},
+		{
+			name:      "mapping with group only no labels key",
+			inputFile: "labelMappingNoLabels.yml",
+			config: HardenRunnerConfig{
+				SkipHardenRunner: true,
+				RunnerLabels:     []string{"ubuntu-latest"},
+			},
+			wantUpdated: false,
+			unchanged:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -321,5 +339,67 @@ func TestAddActionWithContainer(t *testing.T) {
 	}
 	if got != string(input) {
 		t.Errorf("AddAction() with skipContainerJobs=true should not modify the yaml")
+	}
+}
+
+func TestGetActionFromConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config HardenRunnerConfig
+		want   string
+	}{
+		{
+			name:   "extracts uses from config",
+			config: HardenRunnerConfig{Config: "- name: Harden Runner\n  uses: step-security/harden-runner@v2\n  with:\n    egress-policy: audit"},
+			want:   "step-security/harden-runner@v2",
+		},
+		{
+			name:   "extracts custom action path",
+			config: HardenRunnerConfig{Config: "- name: Custom Runner\n  uses: my-org/custom-runner@v1\n  with:\n    mode: strict"},
+			want:   "my-org/custom-runner@v1",
+		},
+		{
+			name:   "falls back when no uses line",
+			config: HardenRunnerConfig{Config: "- name: Harden Runner\n  run: echo hello"},
+			want:   HardenRunnerActionPath,
+		},
+		{
+			name:   "falls back on empty config",
+			config: HardenRunnerConfig{Config: ""},
+			want:   HardenRunnerActionPath,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getActionFromConfig(tt.config)
+			if got != tt.want {
+				t.Errorf("getActionFromConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddActionWithEmptyConfig(t *testing.T) {
+	const inputDirectory = "../../../testfiles/addaction/input"
+	const outputDirectory = "../../../testfiles/addaction/output"
+
+	input, err := ioutil.ReadFile(path.Join(inputDirectory, "labelScalar.yml"))
+	if err != nil {
+		t.Fatalf("error reading test file: %v", err)
+	}
+	// Empty Config should use DefaultHardenRunnerConfig
+	got, gotUpdated, err := AddAction(string(input), HardenRunnerConfig{}, false, false, false)
+	if err != nil {
+		t.Fatalf("AddAction() error = %v", err)
+	}
+	if !gotUpdated {
+		t.Error("AddAction() expected updated = true")
+	}
+	expected, err := ioutil.ReadFile(path.Join(outputDirectory, "labelScalar.yml"))
+	if err != nil {
+		t.Fatalf("error reading output file: %v", err)
+	}
+	if got != string(expected) {
+		t.Errorf("AddAction() with empty config mismatch\nGot:\n%s\nWant:\n%s", got, string(expected))
 	}
 }

--- a/remediation/workflow/hardenrunner/addaction_test.go
+++ b/remediation/workflow/hardenrunner/addaction_test.go
@@ -86,7 +86,7 @@ func TestCustomActionConfig(t *testing.T) {
 		},
 		{
 			name:        "subtractive replaces harden-runner with custom action",
-			inputFile:   "updateConfig.yml",
+			inputFile:   "customActionSubtractive.yml",
 			config:      HardenRunnerConfig{Config: customConfigWithEndpoints, Subtractive: true},
 			wantUpdated: true,
 			outputFile:  "customActionSubtractive.yml",

--- a/testfiles/addaction/input/customAction.yml
+++ b/testfiles/addaction/input/customAction.yml
@@ -1,0 +1,9 @@
+name: test-custom-action
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "build"

--- a/testfiles/addaction/input/customActionSubtractive.yml
+++ b/testfiles/addaction/input/customActionSubtractive.yml
@@ -1,0 +1,14 @@
+name: test-update-config
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v3
+      - run: echo "build"

--- a/testfiles/addaction/input/customActionTwoJobs.yml
+++ b/testfiles/addaction/input/customActionTwoJobs.yml
@@ -1,0 +1,16 @@
+name: test-custom-action-two-jobs
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "build"
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "deploy"

--- a/testfiles/addaction/input/labelMappingNoLabels.yml
+++ b/testfiles/addaction/input/labelMappingNoLabels.yml
@@ -1,0 +1,10 @@
+name: test-label-mapping-no-labels
+on:
+  push:
+jobs:
+  build:
+    runs-on:
+      group: large-runners
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "build"

--- a/testfiles/addaction/input/updateConfigLastStep.yml
+++ b/testfiles/addaction/input/updateConfigLastStep.yml
@@ -1,0 +1,13 @@
+name: test-last-step
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "build"
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit

--- a/testfiles/addaction/output/customAction.yml
+++ b/testfiles/addaction/output/customAction.yml
@@ -1,0 +1,15 @@
+name: test-custom-action
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Security Scanner
+        uses: org/security-scanner@v3
+        with:
+          mode: strict
+          scan-level: deep
+
+      - uses: actions/checkout@v3
+      - run: echo "build"

--- a/testfiles/addaction/output/customActionSubtractive.yml
+++ b/testfiles/addaction/output/customActionSubtractive.yml
@@ -1,0 +1,17 @@
+name: test-update-config
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner
+        uses: acme-corp/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+
+      - uses: actions/checkout@v3
+      - run: echo "build"

--- a/testfiles/addaction/output/customActionTwoJobs.yml
+++ b/testfiles/addaction/output/customActionTwoJobs.yml
@@ -1,0 +1,32 @@
+name: test-custom-action-two-jobs
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner
+        uses: acme-corp/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+
+      - uses: actions/checkout@v3
+      - run: echo "build"
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Harden the runner
+        uses: acme-corp/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+
+      - uses: actions/checkout@v3
+      - run: echo "deploy"

--- a/testfiles/addaction/output/labelNoMatch-skipDisabled.yml
+++ b/testfiles/addaction/output/labelNoMatch-skipDisabled.yml
@@ -1,0 +1,14 @@
+name: test-label-no-match
+on:
+  push:
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v3
+      - run: echo "build"

--- a/testfiles/addaction/output/updateConfigLastStep.yml
+++ b/testfiles/addaction/output/updateConfigLastStep.yml
@@ -1,0 +1,16 @@
+name: test-last-step
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "build"
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443


### PR DESCRIPTION
## Summary
Cherry-pick of test commits from #2593 to bring harden-runner test improvements into int.

- Add test for subtractive update when harden-runner is the last step
- Add `TestGetActionFromConfig` covering uses extraction and fallback
- Add test for empty `HardenRunnerConfig` (default config fallback)
- Add test for `runs-on` mapping with group but no labels key
- Add output assertion to "skip disabled ignores labels" test
- Add `TestCustomActionConfig` with tests for custom action configs (`org/security-scanner@v3`, `acme-corp/harden-runner@v2`)
- Add dedicated input file for each test case

Coverage: 78.1% → 87.6%

## Test plan
- [x] `go test ./remediation/workflow/hardenrunner/ -v` — all pass